### PR TITLE
Update rpi-rgb-led-matrix, fix column calculation, add several missing configuration options 

### DIFF
--- a/examples/animation/main.go
+++ b/examples/animation/main.go
@@ -11,18 +11,28 @@ import (
 )
 
 var (
-	rows       = flag.Int("led-rows", 32, "number of rows supported")
-	parallel   = flag.Int("led-parallel", 1, "number of daisy-chained panels")
-	chain      = flag.Int("led-chain", 2, "number of displays daisy-chained")
-	brightness = flag.Int("brightness", 100, "brightness (0-100)")
+	rows                     = flag.Int("led-rows", 32, "number of rows supported")
+	cols                     = flag.Int("led-cols", 32, "number of columns supported")
+	parallel                 = flag.Int("led-parallel", 1, "number of daisy-chained panels")
+	chain                    = flag.Int("led-chain", 2, "number of displays daisy-chained")
+	brightness               = flag.Int("brightness", 100, "brightness (0-100)")
+	hardware_mapping         = flag.String("led-gpio-mapping", "regular", "Name of GPIO mapping used.")
+	show_refresh             = flag.Bool("led-show-refresh", false, "Show refresh rate.")
+	inverse_colors           = flag.Bool("led-inverse", false, "Switch if your matrix has inverse colors on.")
+	disable_hardware_pulsing = flag.Bool("led-no-hardware-pulse", false, "Don't use hardware pin-pulse generation.")
 )
 
 func main() {
 	config := &rgbmatrix.DefaultConfig
 	config.Rows = *rows
+	config.Cols = *cols
 	config.Parallel = *parallel
 	config.ChainLength = *chain
 	config.Brightness = *brightness
+	config.HardwareMapping = *hardware_mapping
+	config.ShowRefreshRate = *show_refresh
+	config.InverseColors = *inverse_colors
+	config.DisableHardwarePulsing = *disable_hardware_pulsing
 
 	m, err := rgbmatrix.NewRGBLedMatrix(config)
 	fatal(err)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -9,18 +9,28 @@ import (
 )
 
 var (
-	rows       = flag.Int("led-rows", 32, "number of rows supported")
-	parallel   = flag.Int("led-parallel", 1, "number of daisy-chained panels")
-	chain      = flag.Int("led-chain", 2, "number of displays daisy-chained")
-	brightness = flag.Int("brightness", 100, "brightness (0-100)")
+	rows                     = flag.Int("led-rows", 32, "number of rows supported")
+	cols                     = flag.Int("led-cols", 32, "number of columns supported")
+	parallel                 = flag.Int("led-parallel", 1, "number of daisy-chained panels")
+	chain                    = flag.Int("led-chain", 2, "number of displays daisy-chained")
+	brightness               = flag.Int("brightness", 100, "brightness (0-100)")
+	hardware_mapping         = flag.String("led-gpio-mapping", "regular", "Name of GPIO mapping used.")
+	show_refresh             = flag.Bool("led-show-refresh", false, "Show refresh rate.")
+	inverse_colors           = flag.Bool("led-inverse", false, "Switch if your matrix has inverse colors on.")
+	disable_hardware_pulsing = flag.Bool("led-no-hardware-pulse", false, "Don't use hardware pin-pulse generation.")
 )
 
 func main() {
 	config := &rgbmatrix.DefaultConfig
 	config.Rows = *rows
+	config.Cols = *cols
 	config.Parallel = *parallel
 	config.ChainLength = *chain
 	config.Brightness = *brightness
+	config.HardwareMapping = *hardware_mapping
+	config.ShowRefreshRate = *show_refresh
+	config.InverseColors = *inverse_colors
+	config.DisableHardwarePulsing = *disable_hardware_pulsing
 
 	m, err := rgbmatrix.NewRGBLedMatrix(config)
 	fatal(err)

--- a/examples/image/main.go
+++ b/examples/image/main.go
@@ -10,11 +10,16 @@ import (
 )
 
 var (
-	rows       = flag.Int("led-rows", 32, "number of rows supported")
-	parallel   = flag.Int("led-parallel", 1, "number of daisy-chained panels")
-	chain      = flag.Int("led-chain", 2, "number of displays daisy-chained")
-	brightness = flag.Int("brightness", 100, "brightness (0-100)")
-	img        = flag.String("image", "", "image path")
+	rows                     = flag.Int("led-rows", 32, "number of rows supported")
+	cols                     = flag.Int("led-cols", 32, "number of columns supported")
+	parallel                 = flag.Int("led-parallel", 1, "number of daisy-chained panels")
+	chain                    = flag.Int("led-chain", 2, "number of displays daisy-chained")
+	brightness               = flag.Int("brightness", 100, "brightness (0-100)")
+	hardware_mapping         = flag.String("led-gpio-mapping", "regular", "Name of GPIO mapping used.")
+	show_refresh             = flag.Bool("led-show-refresh", false, "Show refresh rate.")
+	inverse_colors           = flag.Bool("led-inverse", false, "Switch if your matrix has inverse colors on.")
+	disable_hardware_pulsing = flag.Bool("led-no-hardware-pulse", false, "Don't use hardware pin-pulse generation.")
+	img                      = flag.String("image", "", "image path")
 
 	rotate = flag.Int("rotate", 0, "rotate angle, 90, 180, 270")
 )
@@ -25,9 +30,14 @@ func main() {
 
 	config := &rgbmatrix.DefaultConfig
 	config.Rows = *rows
+	config.Cols = *cols
 	config.Parallel = *parallel
 	config.ChainLength = *chain
 	config.Brightness = *brightness
+	config.HardwareMapping = *hardware_mapping
+	config.ShowRefreshRate = *show_refresh
+	config.InverseColors = *inverse_colors
+	config.DisableHardwarePulsing = *disable_hardware_pulsing
 
 	m, err := rgbmatrix.NewRGBLedMatrix(config)
 	fatal(err)

--- a/examples/rpc/server/main.go
+++ b/examples/rpc/server/main.go
@@ -8,18 +8,28 @@ import (
 )
 
 var (
-	rows       = flag.Int("led-rows", 32, "number of rows supported")
-	chain      = flag.Int("led-chain", 2, "number of displays daisy-chained")
-	parallel   = flag.Int("led-parallel", 1, "number of daisy-chained panels")
-	brightness = flag.Int("brightness", 100, "brightness (0-100)")
+	rows                     = flag.Int("led-rows", 32, "number of rows supported")
+	cols                     = flag.Int("led-cols", 32, "number of columns supported")
+	parallel                 = flag.Int("led-parallel", 1, "number of daisy-chained panels")
+	chain                    = flag.Int("led-chain", 2, "number of displays daisy-chained")
+	brightness               = flag.Int("brightness", 100, "brightness (0-100)")
+	hardware_mapping         = flag.String("led-gpio-mapping", "regular", "Name of GPIO mapping used.")
+	show_refresh             = flag.Bool("led-show-refresh", false, "Show refresh rate.")
+	inverse_colors           = flag.Bool("led-inverse", false, "Switch if your matrix has inverse colors on.")
+	disable_hardware_pulsing = flag.Bool("led-no-hardware-pulse", false, "Don't use hardware pin-pulse generation.")
 )
 
 func main() {
 	config := &rgbmatrix.DefaultConfig
 	config.Rows = *rows
+	config.Cols = *cols
+	config.Parallel = *parallel
 	config.ChainLength = *chain
 	config.Brightness = *brightness
-	config.Parallel = *parallel
+	config.HardwareMapping = *hardware_mapping
+	config.ShowRefreshRate = *show_refresh
+	config.InverseColors = *inverse_colors
+	config.DisableHardwarePulsing = *disable_hardware_pulsing
 
 	m, err := rgbmatrix.NewRGBLedMatrix(config)
 	fatal(err)

--- a/matrix.go
+++ b/matrix.go
@@ -37,6 +37,7 @@ import (
 // DefaultConfig default WS281x configuration
 var DefaultConfig = HardwareConfig{
 	Rows:              32,
+	Cols:              32,
 	ChainLength:       1,
 	Parallel:          1,
 	PWMBits:           11,
@@ -49,6 +50,8 @@ var DefaultConfig = HardwareConfig{
 type HardwareConfig struct {
 	// Rows the number of rows supported by the display, so 32 or 16.
 	Rows int
+	// Cols the number of columns supported by the display, so 32 or 64 .
+	Cols int
 	// ChainLengthis the number of displays daisy-chained together
 	// (output of one connected to input of next).
 	ChainLength int
@@ -82,12 +85,13 @@ type HardwareConfig struct {
 }
 
 func (c *HardwareConfig) geometry() (width, height int) {
-	return c.Rows * c.ChainLength, c.Rows * c.Parallel
+	return c.Cols * c.ChainLength, c.Rows * c.Parallel
 }
 
 func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o := &C.struct_RGBLedMatrixOptions{}
 	o.rows = C.int(c.Rows)
+	o.cols = C.int(c.Cols)
 	o.chain_length = C.int(c.ChainLength)
 	o.parallel = C.int(c.Parallel)
 	o.pwm_bits = C.int(c.PWMBits)
@@ -132,7 +136,7 @@ func NewRGBLedMatrix(config *HardwareConfig) (c Matrix, err error) {
 			}
 		}
 	}()
-	
+
 	if isMatrixEmulator() {
 		return buildMatrixEmulator(config), nil
 	}

--- a/matrix.go
+++ b/matrix.go
@@ -23,6 +23,18 @@ void led_matrix_swap(struct RGBLedMatrix *matrix, struct LedCanvas *offscreen_ca
 
   offscreen_canvas = led_matrix_swap_on_vsync(matrix, offscreen_canvas);
 }
+
+void set_show_refresh_rate(struct RGBLedMatrixOptions *o, int show_refresh_rate) {
+  o->show_refresh_rate = show_refresh_rate != 0 ? 1 : 0;
+}
+
+void set_disable_hardware_pulsing(struct RGBLedMatrixOptions *o, int disable_hardware_pulsing) {
+  o->disable_hardware_pulsing = disable_hardware_pulsing != 0 ? 1 : 0;
+}
+
+void set_inverse_colors(struct RGBLedMatrixOptions *o, int inverse_colors) {
+  o->inverse_colors = inverse_colors != 0 ? 1 : 0;
+}
 */
 import "C"
 import (
@@ -82,6 +94,9 @@ type HardwareConfig struct {
 
 	ShowRefreshRate bool
 	InverseColors   bool
+
+	// Name of GPIO mapping used
+	HardwareMapping string
 }
 
 func (c *HardwareConfig) geometry() (width, height int) {
@@ -98,9 +113,25 @@ func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o.pwm_lsb_nanoseconds = C.int(c.PWMLSBNanoseconds)
 	o.brightness = C.int(c.Brightness)
 	o.scan_mode = C.int(c.ScanMode)
-	//	o.disable_hardware_pulsing = c.DisableHardwarePulsing
-	//	o.show_refresh_rate = c.ShowRefreshRate
-	//	o.inverse_colors = c.InverseColors
+	o.hardware_mapping = C.CString(c.HardwareMapping)
+
+	if c.ShowRefreshRate == true {
+		C.set_show_refresh_rate(o, C.int(1))
+	} else {
+		C.set_show_refresh_rate(o, C.int(0))
+	}
+
+	if c.DisableHardwarePulsing == true {
+		C.set_disable_hardware_pulsing(o, C.int(1))
+	} else {
+		C.set_disable_hardware_pulsing(o, C.int(0))
+	}
+
+	if c.InverseColors == true {
+		C.set_inverse_colors(o, C.int(1))
+	} else {
+		C.set_inverse_colors(o, C.int(0))
+	}
 
 	return o
 }


### PR DESCRIPTION
There are a few things in this PR:

- Updated the submodule for https://github.com/hzeller/rpi-rgb-led-matrix to that of the current master (as of yesterday). 
- Added HardwareConfig.Cols, allowing for the specification of the number of columns in an LED matrix panel. This corresponds to the "--led-cols" cli option in all of the rpi-rgb-led-matrix demo code.
- Fixed a bug in the calculation of geometry columns, which had previously expected a square panel (columns == rows). In my case, my panels have 32 columns and 16 rows. 
- Added HardwareConfig.HardwareMapping, allowing for the specification of the GPIO mapping type (ex: 'regular', 'adafruit-hat', 'adafruit-hat-pwm', etc). 
- Modified HardwareConfig.toC() so that it now sets bit field options for show_refresh_rate (HardwareConfig.ShowRefreshRate), inverse_colors (HardwareConfig.InverseColors), and disable_hardware_pulsing (HadwareConfig.DisableHardwarePulsing). cgo does not allow for access to bit fields in C structures, so I created setter functions in C to take care of that. 
- Added relevant new cli options to all of the example code. 

I realize, now, 