### PR TITLE
Gpio slowdown

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -196,7 +196,9 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	}
 
 	w, h := config.geometry()
-	m := C.led_matrix_create_from_options(config.toC(), &C.int(*argc), &stringsToC(*argv))
+	cargc := C.int(*argc)
+	cargv := stringsToC(*argv)
+	m := C.led_matrix_create_from_options(config.toC(), &cargc, &cargv)
 	b := C.led_matrix_create_offscreen_canvas(m)
 	c = &RGBLedMatrix{
 		Config: config,

--- a/matrix.go
+++ b/matrix.go
@@ -196,7 +196,7 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	}
 
 	w, h := config.geometry()
-	m := C.led_matrix_create_from_options(config.toC(), argc, &stringsToC(*argv))
+	m := C.led_matrix_create_from_options(config.toC(), &C.int(*argc), &stringsToC(*argv))
 	b := C.led_matrix_create_offscreen_canvas(m)
 	c = &RGBLedMatrix{
 		Config: config,

--- a/matrix.go
+++ b/matrix.go
@@ -120,7 +120,7 @@ func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o.hardware_mapping = C.CString(c.HardwareMapping)
 
 	if c.GPIOSlowdown >= 0 && c.GPIOSlowdown < 3 {
-		C.gpio_slowdown(gpio_slowdown)
+		C.gpio_slowdown(c.GPIOSlowdown)
 	}
 
 	if c.ShowRefreshRate == true {

--- a/matrix.go
+++ b/matrix.go
@@ -4,6 +4,7 @@ package rgbmatrix
 #cgo CFLAGS: -std=c99 -I${SRCDIR}/vendor/rpi-rgb-led-matrix/include -DSHOW_REFRESH_RATE
 #cgo LDFLAGS: -lrgbmatrix -L${SRCDIR}/vendor/rpi-rgb-led-matrix/lib -lstdc++ -lm
 #include <led-matrix-c.h>
+#include <led-matrix.h>
 
 void led_matrix_swap(struct RGBLedMatrix *matrix, struct LedCanvas *offscreen_canvas,
                      int width, int height, const uint32_t pixels[]) {

--- a/matrix.go
+++ b/matrix.go
@@ -188,7 +188,7 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	cargc := C.int(*argc)
 	cargv := stringsToC(*argv)
 	fmt.Printf("ArgV: %#v", *argv)
-	fmt.Printf("CArgV: %#v", cargv)
+	fmt.Printf("CArgV: %#v", **cargv)
 	m := C.led_matrix_create_from_options(config.toC(), &cargc, &cargv)
 	b := C.led_matrix_create_offscreen_canvas(m)
 	c = &RGBLedMatrix{

--- a/matrix.go
+++ b/matrix.go
@@ -56,6 +56,7 @@ var DefaultConfig = HardwareConfig{
 	PWMLSBNanoseconds: 130,
 	Brightness:        100,
 	ScanMode:          Progressive,
+	GPIOSlowdown:      1,
 }
 
 // HardwareConfig rgb-led-matrix configuration

--- a/matrix.go
+++ b/matrix.go
@@ -169,7 +169,7 @@ func stringsToC(s []string) **C.char {
 }
 
 // NewRGBLedMatrix returns a new matrix using the given size and config
-func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matrix, err error) {
+func NewRGBLedMatrix(config *HardwareConfig) (c Matrix, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var ok bool
@@ -185,10 +185,8 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	}
 
 	w, h := config.geometry()
-	cargc := C.int(*argc)
-	cargv := stringsToC(*argv)
-	fmt.Printf("ArgV: %#v", *argv)
-	fmt.Printf("CArgV: %#v", **cargv)
+	cargc := C.int(len(os.Args))
+	cargv := stringsToC(os.Args)
 	m := C.led_matrix_create_from_options(config.toC(), &cargc, &cargv)
 	b := C.led_matrix_create_offscreen_canvas(m)
 	c = &RGBLedMatrix{

--- a/matrix.go
+++ b/matrix.go
@@ -159,7 +159,7 @@ const MatrixEmulatorENV = "MATRIX_EMULATOR"
 func stringsToC(s []string) **C.char {
 	cArray := C.malloc(C.size_t(len(s)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 
-	a := (*[1<<30 - 1]*C.char)(cArray)
+	a := (*[2000]*C.char)(cArray)
 
 	for idx, substring := range s {
 		a[idx] = C.CString(substring)

--- a/matrix.go
+++ b/matrix.go
@@ -58,11 +58,6 @@ var DefaultConfig = HardwareConfig{
 	ScanMode:          Progressive,
 }
 
-type RuntimeOptions struct {
-	// Control speed of GPIO updates. Valid range is 0..3
-	GPIOSlowdown int
-}
-
 // HardwareConfig rgb-led-matrix configuration
 type HardwareConfig struct {
 	// Rows the number of rows supported by the display, so 32 or 16.
@@ -174,6 +169,8 @@ const MatrixEmulatorENV = "MATRIX_EMULATOR"
 
 func stringsToC(s []string) **C.char {
 	cArray := C.malloc(C.size_t(len(s)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+
+	a := (*[len(s) - 1]*C.char)(cArray)
 
 	for idx, substring := range s {
 		a[idx] = C.CString(substring)

--- a/matrix.go
+++ b/matrix.go
@@ -187,6 +187,8 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	w, h := config.geometry()
 	cargc := C.int(*argc)
 	cargv := stringsToC(*argv)
+	fmt.Printf("ArgV: %#v", *argv)
+	fmt.Printf("CArgV: %#v", cargv)
 	m := C.led_matrix_create_from_options(config.toC(), &cargc, &cargv)
 	b := C.led_matrix_create_offscreen_canvas(m)
 	c = &RGBLedMatrix{

--- a/matrix.go
+++ b/matrix.go
@@ -103,17 +103,6 @@ func (c *HardwareConfig) geometry() (width, height int) {
 	return c.Cols * c.ChainLength, c.Rows * c.Parallel
 }
 
-func (r *RuntimeOptions) toC() *C.struct_RuntimeOptions {
-	o := &C.struct_RuntimeOptions{}
-	o.gpio_slowdown = C.int(r.GPIOSlowdown)
-
-	if c.GPIOSlowdown > 0 || c.GPIOSlowdown > 4 {
-		o.gpio_slowdown = 1
-	}
-
-	return o
-}
-
 func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o := &C.struct_RGBLedMatrixOptions{}
 	o.rows = C.int(c.Rows)

--- a/matrix.go
+++ b/matrix.go
@@ -159,8 +159,7 @@ const MatrixEmulatorENV = "MATRIX_EMULATOR"
 func stringsToC(s []string) **C.char {
 	cArray := C.malloc(C.size_t(len(s)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 
-	arglen := len(s) - 1
-	a := (*[arglen]*C.char)(cArray)
+	a := (*[1<<30 - 1]*C.char)(cArray)
 
 	for idx, substring := range s {
 		a[idx] = C.CString(substring)

--- a/matrix.go
+++ b/matrix.go
@@ -215,39 +215,6 @@ func NewRGBLedMatrix(config *HardwareConfig, argc *int, argv *[]string) (c Matri
 	return c, nil
 }
 
-// NewRGBLedMatrix returns a new matrix using the given size and config
-func NewRGBLedMatrixWithOptions(config *HardwareConfig, run *RuntimeOptions) (c Matrix, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			var ok bool
-			err, ok = r.(error)
-			if !ok {
-				err = fmt.Errorf("error creating matrix: %v", r)
-			}
-		}
-	}()
-
-	if isMatrixEmulator() {
-		return buildMatrixEmulator(config), nil
-	}
-
-	w, h := config.geometry()
-	m := C.from_matrix(C.CreateMatrixFromOptions(config.toC(), run.toC()))
-	b := C.led_matrix_create_offscreen_canvas(m)
-	c = &RGBLedMatrix{
-		Config: config,
-		width:  w, height: h,
-		matrix: m,
-		buffer: b,
-		leds:   make([]C.uint32_t, w*h),
-	}
-	if m == nil {
-		return nil, fmt.Errorf("unable to allocate memory")
-	}
-
-	return c, nil
-}
-
 func isMatrixEmulator() bool {
 	if os.Getenv(MatrixEmulatorENV) == "1" {
 		return true

--- a/matrix.go
+++ b/matrix.go
@@ -95,6 +95,9 @@ type HardwareConfig struct {
 	ShowRefreshRate bool
 	InverseColors   bool
 
+	// Control speed of GPIO updates. Valid range is 0..3
+	GPIOSlowdown int
+
 	// Name of GPIO mapping used
 	HardwareMapping string
 }
@@ -114,6 +117,7 @@ func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o.brightness = C.int(c.Brightness)
 	o.scan_mode = C.int(c.ScanMode)
 	o.hardware_mapping = C.CString(c.HardwareMapping)
+	o.gpio_slowdown = C.int(c.GPIOSlowdown)
 
 	if c.ShowRefreshRate == true {
 		C.set_show_refresh_rate(o, C.int(1))

--- a/matrix.go
+++ b/matrix.go
@@ -4,7 +4,7 @@ package rgbmatrix
 #cgo CFLAGS: -std=c99 -I${SRCDIR}/vendor/rpi-rgb-led-matrix/include -DSHOW_REFRESH_RATE
 #cgo LDFLAGS: -lrgbmatrix -L${SRCDIR}/vendor/rpi-rgb-led-matrix/lib -lstdc++ -lm
 #include <led-matrix-c.h>
-#include <led-matrix.h>
+#include "led-matrix.h"
 
 void led_matrix_swap(struct RGBLedMatrix *matrix, struct LedCanvas *offscreen_canvas,
                      int width, int height, const uint32_t pixels[]) {

--- a/matrix.go
+++ b/matrix.go
@@ -118,7 +118,10 @@ func (c *HardwareConfig) toC() *C.struct_RGBLedMatrixOptions {
 	o.brightness = C.int(c.Brightness)
 	o.scan_mode = C.int(c.ScanMode)
 	o.hardware_mapping = C.CString(c.HardwareMapping)
-	o.gpio_slowdown = C.int(c.GPIOSlowdown)
+
+	if c.GPIOSlowdown >= 0 && c.GPIOSlowdown < 3 {
+		C.gpio_slowdown(gpio_slowdown)
+	}
 
 	if c.ShowRefreshRate == true {
 		C.set_show_refresh_rate(o, C.int(1))

--- a/matrix.go
+++ b/matrix.go
@@ -159,7 +159,8 @@ const MatrixEmulatorENV = "MATRIX_EMULATOR"
 func stringsToC(s []string) **C.char {
 	cArray := C.malloc(C.size_t(len(s)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 
-	a := (*[len(s) - 1]*C.char)(cArray)
+	arglen := len(s) - 1
+	a := (*[arglen]*C.char)(cArray)
 
 	for idx, substring := range s {
 		a[idx] = C.CString(substring)


### PR DESCRIPTION
Added passing of command line arguments to C library so runtime options can be used. It is now possible to set `--led-slowdown-gpio 2` so that 64x32 LED matrix works correctly.